### PR TITLE
Prefix frontend API calls with backend URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,9 @@ assessment platform with separate Candidate and Recruiter interfaces.
    npm start
    ```
 
+The frontend expects the backend API to be running at `http://localhost:5000`.
+If your backend is hosted elsewhere, update `frontend/src/api.js` with the
+appropriate base URL.
+
 These applications are simplified to demonstrate the flow of creating
 assessments, submitting code and viewing results.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,3 +9,7 @@ Minimal React frontend with candidate and recruiter dashboards.
    ```bash
    npm start
    ```
+
+The application assumes the backend API is available at
+`http://localhost:5000`. If you run the backend on a different URL,
+edit `src/api.js` to point to the correct location.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,1 @@
+export const BASE_URL = 'http://localhost:5000';

--- a/frontend/src/components/AssessmentPage.jsx
+++ b/frontend/src/components/AssessmentPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { BASE_URL } from '../api';
 
 function AssessmentPage() {
   const { id } = useParams();
@@ -8,7 +9,7 @@ function AssessmentPage() {
   const token = localStorage.getItem('token');
 
   const submit = async () => {
-    const res = await fetch(`/submissions/${id}`, {
+    const res = await fetch(`${BASE_URL}/submissions/${id}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { BASE_URL } from '../api';
 
 function Login() {
   const [email, setEmail] = useState('');
@@ -8,7 +9,7 @@ function Login() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await fetch('/auth/login', {
+    const res = await fetch(`${BASE_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password })

--- a/frontend/src/components/ReportsPage.jsx
+++ b/frontend/src/components/ReportsPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { BASE_URL } from '../api';
 
 function ReportsPage() {
   const { id } = useParams();
@@ -7,7 +8,7 @@ function ReportsPage() {
   const token = localStorage.getItem('token');
 
   useEffect(() => {
-    fetch(`/reports/${id}`, {
+    fetch(`${BASE_URL}/reports/${id}`, {
       headers: { Authorization: `Bearer ${token}` }
     })
       .then((res) => res.json())


### PR DESCRIPTION
## Summary
- centralize backend base URL in `api.js`
- update login, assessment and reports API calls to use base URL
- document backend API address requirement

## Testing
- `npm run build` *(fails: webpack not found)*