### PR TITLE
Implement simple job board

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -52,6 +52,19 @@ class ProctoringLog(db.Model):
     event_type = db.Column(db.String(50))  # e.g., 'TAB_SWITCH', 'COPY_PASTE', 'WEBCAM_DISABLED'
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 
+# --- ATS models ---
+class Job(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text)
+    created_by = db.Column(db.Integer)  # recruiter user id
+
+class Application(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    job_id = db.Column(db.Integer, db.ForeignKey('job.id'))
+    candidate_id = db.Column(db.Integer)
+    status = db.Column(db.String(20), default='applied')
+
 # Create tables and seed initial data if not already present
 @app.before_request
 def create_tables_and_seed():
@@ -76,8 +89,12 @@ def create_tables_and_seed():
         q3 = Question(text='Output Good Morning', sample_input='', expected_output='Good Morning', assessment=assess2)
         q4 = Question(text='Calculate 2*3', sample_input='', expected_output='6', assessment=assess2)
         db.session.add_all([assess1, q1, q2, assess2, q3, q4])
+        # Create sample jobs
+        job1 = Job(title='Frontend Developer', description='Build React apps', created_by=recruiter.id)
+        job2 = Job(title='Backend Developer', description='Work on APIs', created_by=recruiter.id)
+        db.session.add_all([assess1, q1, q2, assess2, q3, q4, job1, job2])
         db.session.commit()
-        print("Seeded initial users, assessments, and questions.")
+        print("Seeded initial users, assessments, questions, and jobs.")
 
 # Utility: role-based access decorator for recruiters
 from functools import wraps
@@ -361,6 +378,69 @@ def get_logs():
             "timestamp": log.timestamp.isoformat()  # return timestamp as string
         })
     return jsonify(result), 200
+
+# --- Job and application endpoints ---
+@app.route('/jobs', methods=['GET', 'POST'])
+@jwt_required()
+def jobs():
+    role = get_jwt().get('role')
+    if request.method == 'GET':
+        jobs = Job.query.all()
+        return jsonify([{
+            'id': j.id,
+            'title': j.title,
+            'description': j.description,
+            'created_by': j.created_by
+        } for j in jobs])
+    else:  # POST
+        if role != 'recruiter':
+            return jsonify({'msg': 'Only recruiters can post jobs'}), 403
+        data = request.get_json()
+        title = data.get('title')
+        if not title:
+            return jsonify({'msg': 'Job title required'}), 400
+        description = data.get('description', '')
+        job = Job(title=title, description=description, created_by=get_jwt_identity())
+        db.session.add(job)
+        db.session.commit()
+        return jsonify({'msg': 'Job created', 'id': job.id}), 201
+
+@app.route('/applications', methods=['POST', 'GET'])
+@jwt_required()
+def applications():
+    role = get_jwt().get('role')
+    if request.method == 'POST':
+        if role != 'candidate':
+            return jsonify({'msg': 'Only candidates can apply'}), 403
+        data = request.get_json()
+        job_id = data.get('job_id')
+        if not job_id:
+            return jsonify({'msg': 'job_id required'}), 400
+        existing = Application.query.filter_by(job_id=job_id, candidate_id=get_jwt_identity()).first()
+        if existing:
+            return jsonify({'msg': 'Already applied'}), 400
+        apprec = Application(job_id=job_id, candidate_id=get_jwt_identity())
+        db.session.add(apprec)
+        db.session.commit()
+        return jsonify({'msg': 'Application submitted'}), 201
+    else:  # GET
+        query = Application.query
+        job_id = request.args.get('job_id')
+        candidate_id = request.args.get('candidate_id')
+        if job_id:
+            query = query.filter_by(job_id=int(job_id))
+        if candidate_id:
+            query = query.filter_by(candidate_id=int(candidate_id))
+        # Recruiters can see all, candidates only their own
+        if role == 'candidate' and not candidate_id:
+            query = query.filter_by(candidate_id=get_jwt_identity())
+        apps = query.all()
+        return jsonify([{
+            'id': a.id,
+            'job_id': a.job_id,
+            'candidate_id': a.candidate_id,
+            'status': a.status
+        } for a in apps])
 
 # Report endpoint
 @app.route('/report/<int:candidate_id>', methods=['GET'])

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import Register from './pages/Register';
 import Profile from './pages/Profile';
 import CodeTest from './pages/CodeTest';
 import Insights from './pages/Insights';
+import CandidateJobs from './pages/CandidateJobs';
 
 // Import pages for recruiters
 import RecruiterDashboard from './pages/RecruiterDashboard';
@@ -19,6 +20,7 @@ import CandidatesList from './pages/CandidatesList';
 import RealTimeMonitor from './pages/RealTimeMonitor';
 import TestSetup from './pages/TestSetup';
 import CandidateReport from './pages/CandidateReport';
+import RecruiterJobs from './pages/RecruiterJobs';
 
 function App() {
   const navigate = useNavigate();
@@ -37,6 +39,7 @@ function App() {
     // Clear token and role from storage and state on logout
     localStorage.removeItem('token');
     localStorage.removeItem('role');
+    localStorage.removeItem('userId');
     setUserRole(null);
     navigate('/login');
   };
@@ -55,6 +58,7 @@ function App() {
               <Button color="inherit" component={Link} to="/candidate/profile">Profile</Button>
               <Button color="inherit" component={Link} to="/candidate/test">Take Test</Button>
               <Button color="inherit" component={Link} to="/candidate/insights">Insights</Button>
+              <Button color="inherit" component={Link} to="/candidate/jobs">Jobs</Button>
             </>
           )}
           {userRole === 'recruiter' && (
@@ -63,6 +67,7 @@ function App() {
               <Button color="inherit" component={Link} to="/recruiter/candidates">Candidates</Button>
               <Button color="inherit" component={Link} to="/recruiter/monitor">Real-Time Monitor</Button>
               <Button color="inherit" component={Link} to="/recruiter/test-setup">Test Setup</Button>
+              <Button color="inherit" component={Link} to="/recruiter/jobs">Jobs</Button>
             </>
           )}
           {userRole && (
@@ -92,12 +97,19 @@ function App() {
                  </PrivateRoute>
                } 
         />
-        <Route path="/candidate/insights" 
+        <Route path="/candidate/insights"
                element={
                  <PrivateRoute allowedRoles={['candidate']}>
                    <Insights />
                  </PrivateRoute>
-               } 
+               }
+        />
+        <Route path="/candidate/jobs"
+               element={
+                 <PrivateRoute allowedRoles={['candidate']}>
+                   <CandidateJobs />
+                 </PrivateRoute>
+               }
         />
 
         {/* Recruiter protected routes */}
@@ -122,12 +134,19 @@ function App() {
                  </PrivateRoute>
                } 
         />
-        <Route path="/recruiter/test-setup" 
+        <Route path="/recruiter/test-setup"
                element={
                  <PrivateRoute allowedRoles={['recruiter']}>
                    <TestSetup />
                  </PrivateRoute>
-               } 
+               }
+        />
+        <Route path="/recruiter/jobs"
+               element={
+                 <PrivateRoute allowedRoles={['recruiter']}>
+                   <RecruiterJobs />
+                 </PrivateRoute>
+               }
         />
         <Route path="/recruiter/report/:candidateId" 
                element={

--- a/frontend/src/pages/CandidateJobs.js
+++ b/frontend/src/pages/CandidateJobs.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Typography, Button, List, ListItem, ListItemText } from '@mui/material';
+
+const CandidateJobs = () => {
+  const [jobs, setJobs] = useState([]);
+  const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    const fetchJobs = async () => {
+      try {
+        const res = await fetch('http://localhost:5000/jobs', {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        const data = await res.json();
+        if (res.ok) {
+          setJobs(data);
+        }
+      } catch (err) {
+        console.error('Failed to load jobs', err);
+      }
+    };
+    fetchJobs();
+  }, [token]);
+
+  const apply = async (jobId) => {
+    try {
+      const res = await fetch('http://localhost:5000/applications', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ job_id: jobId })
+      });
+      if (res.ok) {
+        alert('Applied!');
+      } else {
+        const data = await res.json();
+        alert(data.msg || 'Failed');
+      }
+    } catch (err) {
+      alert('Error applying');
+    }
+  };
+
+  return (
+    <Container sx={{ mt:4 }}>
+      <Typography variant="h6" gutterBottom>Open Jobs</Typography>
+      <List>
+        {jobs.map(job => (
+          <ListItem key={job.id} divider>
+            <ListItemText primary={job.title} secondary={job.description} />
+            <Button variant="contained" onClick={() => apply(job.id)}>Apply</Button>
+          </ListItem>
+        ))}
+      </List>
+    </Container>
+  );
+};
+
+export default CandidateJobs;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -23,9 +23,10 @@ const Login = ({ onLogin }) => {
         throw new Error(data.msg || 'Login failed');
       }
       const data = await response.json();
-      // On success, store token and role, update App state and navigate
+      // On success, store token, role and id, update App state and navigate
       localStorage.setItem('token', data.access_token);
       localStorage.setItem('role', data.user.role);
+      localStorage.setItem('userId', data.user.id);
       onLogin(data.user.role);  // inform App of the logged-in user's role
       if (data.user.role === 'candidate') {
         navigate('/candidate/profile');

--- a/frontend/src/pages/RecruiterJobs.js
+++ b/frontend/src/pages/RecruiterJobs.js
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Typography, TextField, Button, List, ListItem, ListItemText } from '@mui/material';
+
+const RecruiterJobs = () => {
+  const [jobs, setJobs] = useState([]);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const token = localStorage.getItem('token');
+
+  const loadJobs = async () => {
+    const res = await fetch('http://localhost:5000/jobs', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    const data = await res.json();
+    if (res.ok) setJobs(data);
+  };
+
+  useEffect(() => { loadJobs(); }, [token]);
+
+  const createJob = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:5000/jobs', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({ title, description })
+    });
+    if (res.ok) {
+      setTitle('');
+      setDescription('');
+      loadJobs();
+    } else {
+      alert('Failed to create job');
+    }
+  };
+
+  return (
+    <Container sx={{ mt:4 }}>
+      <Typography variant="h6" gutterBottom>Post Job</Typography>
+      <form onSubmit={createJob} style={{ marginBottom: '2rem' }}>
+        <TextField label="Title" fullWidth value={title} onChange={e => setTitle(e.target.value)} margin="normal" required />
+        <TextField label="Description" fullWidth multiline minRows={3} value={description} onChange={e => setDescription(e.target.value)} margin="normal" />
+        <Button variant="contained" type="submit">Create</Button>
+      </form>
+      <Typography variant="h6" gutterBottom>Posted Jobs</Typography>
+      <List>
+        {jobs.map(job => (
+          <ListItem key={job.id} divider>
+            <ListItemText primary={job.title} secondary={job.description} />
+          </ListItem>
+        ))}
+      </List>
+    </Container>
+  );
+};
+
+export default RecruiterJobs;


### PR DESCRIPTION
## Summary
- add Job and Application models with REST endpoints
- seed example job posts
- update login to store user ID
- create CandidateJobs and RecruiterJobs pages
- hook job pages into navbar and routes

## Testing
- `pytest -q`