### PR TITLE
Add job posting feature

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -21,12 +21,14 @@ def create_app():
     from .routes.submissions import submissions_bp
     from .routes.proctoring import proctoring_bp
     from .routes.reports import reports_bp
+    from .routes.jobs import jobs_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(assessments_bp)
     app.register_blueprint(submissions_bp)
     app.register_blueprint(proctoring_bp)
     app.register_blueprint(reports_bp)
+    app.register_blueprint(jobs_bp)
 
     return app
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -32,3 +32,19 @@ class ProctoringEvent(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     event_type = db.Column(db.String(120))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class JobPost(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text)
+    created_by = db.Column(db.Integer, db.ForeignKey('user.id'))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class JobApplication(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    job_id = db.Column(db.Integer, db.ForeignKey('job_post.id'))
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    message = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/backend/routes/jobs.py
+++ b/backend/routes/jobs.py
@@ -1,0 +1,52 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..models import db, JobPost, JobApplication
+
+jobs_bp = Blueprint('jobs', __name__, url_prefix='/jobs')
+
+@jobs_bp.route('/', methods=['POST'])
+@jwt_required()
+def create_job():
+    identity = get_jwt_identity()
+    if identity['role'] != 'recruiter':
+        return jsonify({'message': 'Only recruiters can post jobs'}), 403
+    data = request.get_json()
+    job = JobPost(title=data.get('title'), description=data.get('description'), created_by=identity['id'])
+    db.session.add(job)
+    db.session.commit()
+    return jsonify({'id': job.id})
+
+@jobs_bp.route('/', methods=['GET'])
+@jwt_required()
+def list_jobs():
+    jobs = JobPost.query.all()
+    return jsonify([
+        {'id': j.id, 'title': j.title, 'description': j.description}
+        for j in jobs
+    ])
+
+@jobs_bp.route('/<int:job_id>/apply', methods=['POST'])
+@jwt_required()
+def apply_job(job_id):
+    identity = get_jwt_identity()
+    if identity['role'] != 'candidate':
+        return jsonify({'message': 'Only candidates can apply'}), 403
+    data = request.get_json()
+    application = JobApplication(job_id=job_id, user_id=identity['id'], message=data.get('message'))
+    db.session.add(application)
+    db.session.commit()
+    return jsonify({'status': 'applied'})
+
+@jobs_bp.route('/<int:job_id>/applications', methods=['GET'])
+@jwt_required()
+def list_applications(job_id):
+    identity = get_jwt_identity()
+    job = JobPost.query.get_or_404(job_id)
+    if identity['role'] != 'recruiter' or identity['id'] != job.created_by:
+        return jsonify({'message': 'Forbidden'}), 403
+    applications = JobApplication.query.filter_by(job_id=job_id).all()
+    return jsonify([
+        {'user_id': a.user_id, 'message': a.message}
+        for a in applications
+    ])

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import CandidateDashboard from './components/CandidateDashboard';
 import RecruiterDashboard from './components/RecruiterDashboard';
 import AssessmentPage from './components/AssessmentPage';
 import ReportsPage from './components/ReportsPage';
+import JobsPage from './components/JobsPage';
 
 function App() {
   const role = localStorage.getItem('role');
@@ -17,6 +18,10 @@ function App() {
         <Route
           path="/candidate"
           element={token && role === 'candidate' ? <CandidateDashboard /> : <Navigate to="/" />}
+        />
+        <Route
+          path="/candidate/jobs"
+          element={token && role === 'candidate' ? <JobsPage /> : <Navigate to="/" />}
         />
         <Route
           path="/recruiter/*"

--- a/frontend/src/components/CandidateDashboard.jsx
+++ b/frontend/src/components/CandidateDashboard.jsx
@@ -8,6 +8,8 @@ function CandidateDashboard() {
       <Link to="/assessment/1">Take Assessment</Link>
       <br />
       <Link to="/reports/1">View Report</Link>
+      <br />
+      <Link to="/candidate/jobs">Jobs</Link>
     </div>
   );
 }

--- a/frontend/src/components/JobsPage.jsx
+++ b/frontend/src/components/JobsPage.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { API_BASE } from '../api';
+
+function JobsPage() {
+  const [jobs, setJobs] = useState([]);
+  const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    fetch(`${API_BASE}/jobs/`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+      .then((res) => res.json())
+      .then((data) => setJobs(data));
+  }, [token]);
+
+  const apply = async (id) => {
+    await fetch(`${API_BASE}/jobs/${id}/apply`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({})
+    });
+    alert('Applied');
+  };
+
+  return (
+    <div>
+      <h2>Jobs</h2>
+      <ul>
+        {jobs.map((j) => (
+          <li key={j.id}>
+            {j.title}
+            <button onClick={() => apply(j.id)}>Apply</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default JobsPage;

--- a/frontend/src/components/PostJobPage.jsx
+++ b/frontend/src/components/PostJobPage.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { API_BASE } from '../api';
+
+function PostJobPage() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const token = localStorage.getItem('token');
+
+  const submit = async () => {
+    await fetch(`${API_BASE}/jobs/`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ title, description })
+    });
+    setTitle('');
+    setDescription('');
+    alert('Posted');
+  };
+
+  return (
+    <div>
+      <h2>Post Job</h2>
+      <input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Title"
+      />
+      <br />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <br />
+      <button onClick={submit}>Submit</button>
+    </div>
+  );
+}
+
+export default PostJobPage;

--- a/frontend/src/components/RecruiterDashboard.jsx
+++ b/frontend/src/components/RecruiterDashboard.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { Link, Routes, Route } from 'react-router-dom';
 import ReportsPage from './ReportsPage';
+import PostJobPage from './PostJobPage';
 
 function Home() {
   return (
     <div>
       <h2>Recruiter Dashboard</h2>
       <Link to="reports/1">Candidate Report</Link>
+      <br />
+      <Link to="post-job">Post Job</Link>
     </div>
   );
 }
@@ -16,6 +19,7 @@ function RecruiterDashboard() {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="reports/:id" element={<ReportsPage />} />
+      <Route path="post-job" element={<PostJobPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- add `JobPost` and `JobApplication` models
- create REST endpoints for jobs and applications
- wire up routes in backend
- expose simple job board and posting UI in React

## Testing
- `pytest`
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683d7539dc388330ad54e218b8f4ef83